### PR TITLE
country Brasil environment dev delete

### DIFF
--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -37,7 +37,7 @@ jobs:
   planning:
     if: github.event_name == 'pull_request'
     needs: [ verifier ]
-    uses: lisboajeff/bucket_python/.github/workflows/action.yml@feature/planning
+    uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
     secrets: inherit
     with:
       base_path: "${{ needs.verifier.outputs.country }}/${{ needs.verifier.outputs.environment }}/certificates"
@@ -48,7 +48,7 @@ jobs:
 
   push_to_main:
     if: github.ref == 'refs/heads/main' && github.event.pull_request.merged == true
-    uses: lisboajeff/bucket_python/.github/workflows/action.yml@feature/planning
+    uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
     secrets: inherit
     with:
       base_path: "${{ needs.verifier.outputs.country }}/${{ needs.verifier.outputs.environment }}/certificates"

--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -3,10 +3,13 @@ name: Planning Files to S3
 on:
   pull_request:
     types: [ opened, synchronize, ready_for_review, edited ]
-
+  push:
+    branches:
+      - main
 jobs:
 
   verifier:
+    if: github.event_name == 'pull_request'
     outputs:
       country: ${{ steps.check.outputs.country }}
       environment: ${{ steps.check.outputs.environment }}
@@ -32,6 +35,7 @@ jobs:
           cat "$GITHUB_OUTPUT"
 
   planning:
+    if: github.event_name == 'pull_request'
     needs: [ verifier ]
     uses: lisboajeff/bucket_python/.github/workflows/action.yml@feature/planning
     secrets: inherit
@@ -43,7 +47,6 @@ jobs:
       type: 'planning'
 
   push_to_main:
-    needs: [ planning ]
     if: github.ref == 'refs/heads/main' && github.event.pull_request.merged == true
     uses: lisboajeff/bucket_python/.github/workflows/action.yml@feature/planning
     secrets: inherit


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow (sync_bucket.yml) to include actions on 'push' events for the 'main' branch. It also restricts 'verifier' and 'planning' jobs to only execute on 'pull_request' events. Last, it removes a dependency on the 'planning' job for the 'push_to_main' job.