### PR TITLE
country Brasil environment dev delete

### DIFF
--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -47,7 +47,7 @@ jobs:
       type: 'planning'
 
   push_to_main:
-    if: github.ref == 'refs/heads/main' && github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
The condition for executing the `push_to_main` part of the GitHub workflow has been simplified. Now, it will run whenever a pull request is merged, regardless of which branch it is on.