### PR TITLE
country Brasil environment dev update

### DIFF
--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -47,7 +47,7 @@ jobs:
       type: 'planning'
 
   push_to_main:
-    if: github.event.pull_request.merged == true
+    if: github.ref == 'refs/heads/main'
     uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
The condition to push to main branch in the GitHub actions workflow has been changed. Instead of checking if a pull request has been merged, it now checks if the current reference is the main branch. This ensures the action is triggered only on main branch updates.