### PR TITLE
country Brasil environment dev FIX

### DIFF
--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -53,13 +53,12 @@ jobs:
         run: echo "OK"
 
   apply:
-    needs: execute_planning
+    needs: approval
     uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
     with:
       base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"
       description: "${{ needs.setup.outputs.country }}:${{ needs.setup.outputs.environment }}"
       configuration: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/config.env"
       directory_properties: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/directory.properties"
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       type: 'apply'
+    secrets: inherit

--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -53,7 +53,7 @@ jobs:
         run: echo "OK"
 
   apply:
-    needs: approval
+    needs: [approval, setup]
     uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
     with:
       base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"

--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -6,16 +6,19 @@ on:
   push:
     branches:
       - main
-jobs:
 
-  planning:
+jobs:
+  setup:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    outputs:
+      country: ${{ steps.check.outputs.country }}
+      environment: ${{ steps.check.outputs.environment }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Check Title Message
-        id: check
+        id: set-vars
         run: |
           TITLE="${{ github.event.pull_request.title }}"
           TITLE_REGEX='^country [a-zA-Z]{0,20} environment [a-zA-Z]{0,5} [a-zA-Z][a-zA-Z0-9,]{0,49}$'
@@ -27,50 +30,34 @@ jobs:
           fi
           COUNTRY=$(echo "$TITLE" | cut -d ' ' -f 2)
           ENVIRONMENT=$(echo "$TITLE" | cut -d ' ' -f 4)
-          echo "COUNTRY=$COUNTRY" >> $GITHUB_ENV
-          echo "ENVIRONMENT=$ENVIRONMENT" >> $GITHUB_ENV
-      - name: Execute Planning
-        uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
-        with:
-          base_path: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/certificates"
-          description: "${{ env.COUNTRY }}:${{ env.ENVIRONMENT }}"
-          configuration: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/config.env"
-          directory_properties: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/directory.properties"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          type: 'planning'
-      - name: Save Environment Variables
-        run: |
-          echo "COUNTRY=$COUNTRY" >> env.txt
-          echo "ENVIRONMENT=$ENVIRONMENT" >> env.txt
-      - name: Upload Environment File as Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: env-file
-          path: env.txt
+          echo "country=$COUNTRY" >> $GITHUB_OUTPUT
+          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
+          cat "$GITHUB_OUTPUT"
+
+  execute_planning:
+    if: github.event_name == 'pull_request'
+    needs: setup
+    uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
+    with:
+      base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"
+      description: "${{ needs.setup.outputs.country }}:${{ needs.setup.outputs.environment }}"
+      configuration: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/config.env"
+      directory_properties: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/directory.properties"
+      type: 'planning'
+    secrets: inherit
 
   apply:
-    needs: planning
+    needs: execute_planning
     runs-on: ubuntu-latest
     environment: approval
     steps:
-      - name: Download Environment File
-        uses: actions/download-artifact@v2
-        with:
-          name: env-file
-          path: .
-      - name: Load Environment Variables
-        run: |
-          readarray -t env_vars < env.txt
-          COUNTRY="${env_vars[0]}"  >> $GITHUB_ENV
-          ENVIRONMENT="${env_vars[1]}"  >> $GITHUB_ENV
       - name: Execute Apply
         uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
         with:
-          base_path: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/certificates"
-          description: "${{ env.COUNTRY }}:${{ env.ENVIRONMENT }}"
-          configuration: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/config.env"
-          directory_properties: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/directory.properties"
+          base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"
+          description: "${{ needs.setup.outputs.country }}:${{ needs.setup.outputs.environment }}"
+          configuration: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/config.env"
+          directory_properties: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/directory.properties"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           type: 'apply'

--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -8,11 +8,8 @@ on:
       - main
 jobs:
 
-  verifier:
+  planning:
     if: github.event_name == 'pull_request'
-    outputs:
-      country: ${{ steps.check.outputs.country }}
-      environment: ${{ steps.check.outputs.environment }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -30,29 +27,50 @@ jobs:
           fi
           COUNTRY=$(echo "$TITLE" | cut -d ' ' -f 2)
           ENVIRONMENT=$(echo "$TITLE" | cut -d ' ' -f 4)
-          echo "country=$COUNTRY" >> $GITHUB_OUTPUT
-          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
-          cat "$GITHUB_OUTPUT"
+          echo "COUNTRY=$COUNTRY" >> $GITHUB_ENV
+          echo "ENVIRONMENT=$ENVIRONMENT" >> $GITHUB_ENV
+      - name: Execute Planning
+        uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
+        with:
+          base_path: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/certificates"
+          description: "${{ env.COUNTRY }}:${{ env.ENVIRONMENT }}"
+          configuration: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/config.env"
+          directory_properties: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/directory.properties"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          type: 'planning'
+      - name: Save Environment Variables
+        run: |
+          echo "COUNTRY=$COUNTRY" >> env.txt
+          echo "ENVIRONMENT=$ENVIRONMENT" >> env.txt
+      - name: Upload Environment File as Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: env-file
+          path: env.txt
 
-  planning:
-    if: github.event_name == 'pull_request'
-    needs: [ verifier ]
-    uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
-    secrets: inherit
-    with:
-      base_path: "${{ needs.verifier.outputs.country }}/${{ needs.verifier.outputs.environment }}/certificates"
-      description: "${{ needs.verifier.outputs.country }}:${{ needs.verifier.outputs.environment }}"
-      configuration: "${{ needs.verifier.outputs.country }}/${{ needs.verifier.outputs.environment }}/config.env"
-      directory_properties: "${{ needs.verifier.outputs.country }}/${{ needs.verifier.outputs.environment }}/directory.properties"
-      type: 'planning'
-
-  push_to_main:
-    if: github.ref == 'refs/heads/main'
-    uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
-    secrets: inherit
-    with:
-      base_path: "${{ needs.verifier.outputs.country }}/${{ needs.verifier.outputs.environment }}/certificates"
-      description: "${{ needs.verifier.outputs.country }}:${{ needs.verifier.outputs.environment }}"
-      configuration: "${{ needs.verifier.outputs.country }}/${{ needs.verifier.outputs.environment }}/config.env"
-      directory_properties: "${{ needs.verifier.outputs.country }}/${{ needs.verifier.outputs.environment }}/directory.properties"
-      type: 'apply'
+  apply:
+    needs: planning
+    runs-on: ubuntu-latest
+    environment: approval
+    steps:
+      - name: Download Environment File
+        uses: actions/download-artifact@v2
+        with:
+          name: env-file
+          path: .
+      - name: Load Environment Variables
+        run: |
+          readarray -t env_vars < env.txt
+          COUNTRY="${env_vars[0]}"  >> $GITHUB_ENV
+          ENVIRONMENT="${env_vars[1]}"  >> $GITHUB_ENV
+      - name: Execute Apply
+        uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
+        with:
+          base_path: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/certificates"
+          description: "${{ env.COUNTRY }}:${{ env.ENVIRONMENT }}"
+          configuration: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/config.env"
+          directory_properties: "${{ env.COUNTRY }}/${{ env.ENVIRONMENT }}/directory.properties"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          type: 'apply'

--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -50,7 +50,6 @@ jobs:
     environment: approved
     steps:
       - name: Request approval
-        uses: actions/github-script@v4
         run: echo "OK"
 
   apply:

--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -11,8 +11,8 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      country: ${{ steps.check.outputs.country }}
-      environment: ${{ steps.check.outputs.environment }}
+      country: ${{ steps.set-vars.outputs.country }}
+      environment: ${{ steps.set-vars.outputs.environment }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
           cat "$GITHUB_OUTPUT"
 
   execute_planning:
-    needs: setup
+    needs: [ setup ]
     uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
     with:
       base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"

--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   setup:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       country: ${{ steps.check.outputs.country }}
@@ -35,7 +34,6 @@ jobs:
           cat "$GITHUB_OUTPUT"
 
   execute_planning:
-    if: github.event_name == 'pull_request'
     needs: setup
     uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
     with:

--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -38,7 +38,7 @@ jobs:
     uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
     with:
       base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"
-      description: "${{ needs.setup.outputs.country }}:${{ needs.setup.outputs.environment }}"
+      description: "planning changes to the bucket"
       configuration: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/config.env"
       directory_properties: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/directory.properties"
       type: 'planning'
@@ -57,7 +57,7 @@ jobs:
     uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
     with:
       base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"
-      description: "${{ needs.setup.outputs.country }}:${{ needs.setup.outputs.environment }}"
+      description: "Performing changes to the bucket"
       configuration: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/config.env"
       directory_properties: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/directory.properties"
       type: 'apply'

--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -47,12 +47,15 @@ jobs:
   apply:
     needs: execute_planning
     environment: approval
-    uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
-    with:
-      base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"
-      description: "${{ needs.setup.outputs.country }}:${{ needs.setup.outputs.environment }}"
-      configuration: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/config.env"
-      directory_properties: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/directory.properties"
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      type: 'apply'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Applay
+        uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
+        with:
+          base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"
+          description: "${{ needs.setup.outputs.country }}:${{ needs.setup.outputs.environment }}"
+          configuration: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/config.env"
+          directory_properties: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/directory.properties"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          type: 'apply'

--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -44,18 +44,23 @@ jobs:
       type: 'planning'
     secrets: inherit
 
+  approval:
+    needs: execute_planning
+    runs-on: ubuntu-latest
+    environment: approved
+    steps:
+      - name: Request approval
+        uses: actions/github-script@v4
+        run: echo "OK"
+
   apply:
     needs: execute_planning
-    environment: approval
-    runs-on: ubuntu-latest
-    steps:
-      - name: Applay
-        uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
-        with:
-          base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"
-          description: "${{ needs.setup.outputs.country }}:${{ needs.setup.outputs.environment }}"
-          configuration: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/config.env"
-          directory_properties: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/directory.properties"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          type: 'apply'
+    uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
+    with:
+      base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"
+      description: "${{ needs.setup.outputs.country }}:${{ needs.setup.outputs.environment }}"
+      configuration: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/config.env"
+      directory_properties: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/directory.properties"
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      type: 'apply'

--- a/.github/workflows/sync_bucket.yml
+++ b/.github/workflows/sync_bucket.yml
@@ -46,16 +46,13 @@ jobs:
 
   apply:
     needs: execute_planning
-    runs-on: ubuntu-latest
     environment: approval
-    steps:
-      - name: Execute Apply
-        uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
-        with:
-          base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"
-          description: "${{ needs.setup.outputs.country }}:${{ needs.setup.outputs.environment }}"
-          configuration: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/config.env"
-          directory_properties: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/directory.properties"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          type: 'apply'
+    uses: lisboajeff/bucket_python/.github/workflows/action.yml@main
+    with:
+      base_path: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/certificates"
+      description: "${{ needs.setup.outputs.country }}:${{ needs.setup.outputs.environment }}"
+      configuration: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/config.env"
+      directory_properties: "${{ needs.setup.outputs.country }}/${{ needs.setup.outputs.environment }}/directory.properties"
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      type: 'apply'


### PR DESCRIPTION
The verifier job has been removed and incorporated into the planning job instead. Environment variables are now utilized for assigning the country and environment, which replaces the verifier's output previously used for these specific details. Secrets have been added to the 'planning' and 'apply' steps to manage AWS access and the 'apply' step now depends on the 'planning' job to ensure correct order of execution. The environment variables are also saved in an artifact file for use in the 'apply' job.